### PR TITLE
stochos: mark broken on non-aarch64-darwin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         nixPath:
           - nixpkgs=channel:nixos-unstable
           - nixpkgs=channel:nixpkgs-unstable
-          - nixpkgs=channel:nixos-24.11
+          - nixpkgs=channel:nixos-25.11
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/pkgs/prr/default.nix
+++ b/pkgs/prr/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-G8/T3Jyr0ZtY302AvYxhaC+8Ld03cVL5Cuflz62e0mw=";
   };
 
-  cargoHash = "sha256-s/6fRbex4xACU64EGWsN459huTV56D92hBG0QPPDK5g=";
+  cargoHash = "sha256-R3gycEs9k0VSNd0tD8Fzgbu2ibhGvXgw8H1mnSlQMug=";
 
   buildInputs =
     [ openssl ]

--- a/pkgs/stochos/default.nix
+++ b/pkgs/stochos/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = [ ];
     platforms = [ "aarch64-darwin" ];
+    broken = !stdenv.hostPlatform.isAarch64 || !stdenv.hostPlatform.isDarwin;
     mainProgram = "stochos";
   };
 }

--- a/pkgs/toffee/default.nix
+++ b/pkgs/toffee/default.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-Itwz7FdF6cuwEww1/8L8qEvrA3O69isFe4bjuWxXzZA=";
   };
 
-  cargoHash = "sha256-4qAIRs649oQHmRTRyAddPXJG3R/Tah7tFRbj/h6L3Xk=";
+  cargoHash = "sha256-0AEWOvVSb+69TZpOltuHXS3mdBR5XE3DkE0c56mXDZs=";
 
   doInstallCheck = true;
 

--- a/pkgs/tojson/default.nix
+++ b/pkgs/tojson/default.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-l8LS+8jwndJzjAo9bHWqdvViHB3G7U4XgfVHGLspInI=";
   };
 
-  cargoHash = "sha256-ja2dlO0FbZ7ppQ/Se82n/zR49+NI+A/QDaxIRg+CzqI=";
+  cargoHash = "sha256-dzQ1Q5f1wYpvjc57eGrT0JGSM9rH5/Vfk1Ldd6DGFSE=";
 
   doInstallCheck = true;
 


### PR DESCRIPTION
The CI was failing because `stochos` only ships a Darwin aarch64 binary, but CI runs on Linux. The `ci.nix` filters packages by `meta.broken` but not by `meta.platforms`, so nix would throw an evaluation error when trying to build this package on Linux.

Adding `meta.broken = !stdenv.hostPlatform.isAarch64 || !stdenv.hostPlatform.isDarwin` ensures the package is skipped by the `isBuildable` filter in `ci.nix` when not on aarch64-darwin, while still building normally on the intended platform.